### PR TITLE
fixed ground intake angles

### DIFF
--- a/src/main/java/frc/robot/RobotVisualizer.java
+++ b/src/main/java/frc/robot/RobotVisualizer.java
@@ -63,7 +63,7 @@ public class RobotVisualizer {
 
     m_arm.setAngle(-armAngle - 90);
 
-    m_ground_intake.setAngle(groundIntakeAngle + 90);
+    m_ground_intake.setAngle(-groundIntakeAngle + 90);
 
     m_elevator.setLength(elevatorHeight + Units.inchesToMeters(37.2));
   }

--- a/src/main/java/frc/robot/subsystems/groundIntake/GroundIntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/groundIntake/GroundIntakeConstants.java
@@ -11,8 +11,8 @@ public class GroundIntakeConstants {
 
   public static final double ENCODER_OFFSET = 235.0;
 
-  public static final double GROUND_INTAKE_LOWER_BOUND = 0.0;
-  public static final double GROUND_INTAKE_UPPER_BOUND = 95.0;
+  public static final double GROUND_INTAKE_LOWER_BOUND = -120.0;
+  public static final double GROUND_INTAKE_UPPER_BOUND = 10.0;
 
   public static final double MAX_VELOCITY = 1.2;
   public static final double MAX_ACCELERATION = 1.5;


### PR DESCRIPTION
Fixed the angles because they flipped the encoder meaning I had to go to -90 degrees instead of 90 degrees.